### PR TITLE
Allow any 1.x version of Elixir

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Quinn.Mixfile do
   def project do
     [app: :quinn,
      version: "0.0.4",
-     elixir: "~> 1.0.0",
+     elixir: "~> 1.0",
      deps: deps,
      description: description,
      package: package]


### PR DESCRIPTION
I'm running Elixir 1.2.4 and I see this warning during the compile step:

```
warning: the dependency :quinn requires Elixir "~> 1.0.0" but you are running on v1.2.3
```

I figured changing this line to a `~> 1.0` dependency would be a good fix for this issue.
