### PR TITLE
bump Elixir version to 1.3

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Quinn.Mixfile do
   def project do
     [app: :quinn,
      version: "0.0.5",
-     elixir: "~> 1.0",
+     elixir: "~> 1.3",
      deps: deps,
      description: description,
      package: package]


### PR DESCRIPTION
Hey there, Quinn works fine on Elixir 1.3 - this avoids a compile warning:

```
➔ mix test
===> Compiling idna
===> Compiling mimerl
==> quinn
warning: the dependency :quinn requires Elixir "~> 1.0.0" but you are running on v1.3.0
Compiling 3 files (.ex)
Generated quinn app
```
