### PR TITLE
naive_map

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,23 @@ The result will be
 ```elixir
 [%{attr: [], name: :line, value: ["that"]}]
 ```
+
+# Naive Map
+
+Converts xml string to an Elixir map which is convenient since no set-up is required (no xpath specification).  This tool is inspired by the convenience of Rails Hash.from_xml() but is "naive" in that it carries the same drawbacks.  Attributes on nodes don't carry over if the node has just one text value.  Sometimes you will get lists or a map key depending on the cardinality of sibling nodes detected at a level.  
+
+For example 
+
+```elixir
+Quinn.naive_map("<transaction><order>1</order><order>2</order></transaction>")
+#detects 2 siblings so you'll get:
+%{transaction: %{order: ["1", "2"]}}
+#But if no siblings, you'll not get a list:
+Quinn.naive_map("<transaction><order>3</order></transaction>")
+%{transaction: %{order: "3"}}
+```
+
+
 Please refer to the tests if you want to see more example on how it is used.
 
 Please let me know if you come across any problem. I'm still new to Elixir so feel free to contribute or clean up the code.

--- a/lib/quinn.ex
+++ b/lib/quinn.ex
@@ -7,4 +7,9 @@ defmodule Quinn do
   def find(node, node_names) do
     Quinn.XmlNodeFinder.find(node, node_names)
   end
+
+  def naive_map(xml) do
+    Quinn.XmlParser.parse(xml) |> Quinn.NaiveMap.parse
+  end
+
 end

--- a/lib/xml_parser/naive_map.ex
+++ b/lib/xml_parser/naive_map.ex
@@ -1,0 +1,32 @@
+defmodule Quinn.NaiveMap do
+
+  # root case
+  def parse([node]) do
+    parse(node)
+  end
+
+  # peer siblings, collect a list
+  def parse([%{name: name}, %{name: name} | _] = list)  do
+    %{name => Enum.map(list, fn elem -> parse(elem.value) end)}
+  end
+  # different siblings, merge into map
+  def parse(list) when is_list(list) and length(list) > 1  do
+    Enum.reduce list, %{}, fn elem, acc ->
+      parse(elem) |> Map.merge(acc) 
+    end
+  end
+
+  # #one element as value, parse that value
+  def parse(%{name: name, value: [value]}) do
+    %{name => parse(value)}
+  end
+  #many children under this node, merge them all under one map
+  def parse(%{attr: attr, name: name, value: list}) when is_list(list) and length(list) > 1 do
+    %{name => Map.new(attr) |> Map.merge(parse(list))}
+  end
+  # #when value is node text
+  def parse(value) do
+    value
+  end
+
+end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,2 @@
+%{"earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}

--- a/test/xml_parser/naive_map_test.exs
+++ b/test/xml_parser/naive_map_test.exs
@@ -1,0 +1,67 @@
+defmodule Quinn.NaiveMapTest do
+  use ExUnit.Case
+
+
+
+  test "produces a naive map" do
+    expectation = %{Orders: 
+                    %{foo: "bar",
+                      order: [
+                        %{billing_address: "My address", 
+                          id: "123",
+                          items: %{item: %{description: "Hat", 
+                                           itemfoo: "itembar", 
+                                           price: "5.99",
+                                           quantity: "1", 
+                                           sku: "ABC"}
+                                  }
+                        },
+                        %{billing_address: "Uncle's House", 
+                          id: "124",
+                          items: %{item: %{description: "Hat", 
+                                           price: "5.99", 
+                                           quantity: "2",
+                                           sku: "ABC"}
+                                  }
+                        }
+                      ]
+                    }
+                  }
+    actual = Quinn.naive_map(sample_xml)
+    assert actual == expectation
+  end
+  
+
+  def sample_xml do
+    """
+    <Orders foo="bar">
+      <order>
+        <id>123</id>
+        <billing_address>My address</billing_address>
+        <items itemsfoo="itemsbar">
+          <item itemfoo="itembar">
+            <sku skufoo="skubar">ABC</sku>
+            <description>Hat</description>
+            <price>5.99</price>
+            <quantity>
+              1
+            </quantity>
+          </item>
+        </items>
+      </order>
+      <order>
+        <id>124</id>
+        <billing_address>Uncle's House</billing_address>
+        <items>
+          <item>
+            <sku>ABC</sku>
+            <description>Hat</description>
+            <price>5.99</price>
+            <quantity>2</quantity>
+          </item>
+        </items>
+      </order>
+    </Orders>
+    """
+  end
+end


### PR DESCRIPTION
# Naive Map

Converts xml string to an Elixir map which is convenient since no set-up is required (no xpath specification).  This tool is inspired by the convenience of Rails Hash.from_xml() but is "naive" in that it carries the same drawbacks.  Attributes on nodes don't carry over if the node has just one text value.  Sometimes you will get lists or a map key depending on the cardinality of sibling nodes detected at a level.  

For example 

```elixir
Quinn.naive_map("<transaction><order>1</order><order>2</order></transaction>")
#detects 2 siblings so you'll get:
%{transaction: %{order: ["1", "2"]}}
#But if no siblings, you'll not get a list:
Quinn.naive_map("<transaction><order>3</order></transaction>")
%{transaction: %{order: "3"}}
```

Added a test.

Updated README.