### PR TITLE
Add parentheses to prevent warnings in Elixir 1.4

### DIFF
--- a/lib/xml_parser/xml_parser.ex
+++ b/lib/xml_parser/xml_parser.ex
@@ -31,7 +31,7 @@ defmodule Quinn.XmlParser do
     end
   end
 
-  defp parse_record({:xmlComment, _, _, _, value}) do
+  defp parse_record({:xmlComment, _, _, _, _value}) do
     []
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,9 +6,9 @@ defmodule Quinn.Mixfile do
       app: :quinn,
       version: "1.0.1",
       elixir: "~> 1.3",
-      deps: deps,
-      description: description,
-      package: package
+      deps: deps(),
+      description: description(),
+      package: package()
     ]
   end
 


### PR DESCRIPTION
removes warnings caused by Elixir 1.4's stricter syntax: 
```
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:9

warning: variable "description" does not exist and is being expanded to "description()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:10

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:11

warning: variable "value" is unused
  lib/xml_parser/xml_parser.ex:34
```

The visual noise they create drives me bonkers, and since you say you're busy, I figured you wouldn't mind if I took care of them for you :)