### PR TITLE
Add the ability to parse xml without namespaces/key prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,44 @@
 Quinn
+=====
 
-A simple XML parser in Elixir aims to parse rss/atom feeds. I'm currently using xmerl_scan.string to parse the xml. I'm a bit busy so I may take awhile to response and/or update. Feel free to send a pull request. Otherwise, check out hex for other XML parsers that may be better maintained.
+A simple XML parser in Elixir aims to parse rss/atom feeds. I'm currently
+using `xmerl_scan.string` to parse the xml. I'm a bit busy so I may take awhile to response and/or update. Feel free to send a pull request. Otherwise, check out [hex](https://hex.pm/packages?search=xml&sort=downloads) for other XML parsers that may be better maintained.
 
 Note: I am not parsing comment at the moment. It does handle comment, but it just ignores it. Hopefully I will update it soon. Sorry!
 
-Parsing
+# Parsing
 
+
+```elixir
 Quinn.parse("<head><title short_name = \"yah\">Yahoo</title><title:content>Bing</title:content></head>")
+```
 Calling parse on the xml will produce
-
+```elixir
 [%{attr: [], name: :head,
    value: [%{attr: [short_name: "yah"], name: :title, value: ["Yahoo"]},
            %{attr: [], name: :"title:content", value: ["Bing"]}]}]
+```
 Parsing xml without namespaces(key prefix)
-
+```elixir
 xml = "<m:return xsi:type="d4p1:Answer">
       <d4p1:Title> Title </d4p1:Title>
       <d4p1:Description> Description </d4p1:Description>
      </m:return>"
 
 Quinn.parse(xml, :strip_namespaces)
-Calling parse on the xml will produce
+```
 
+Calling parse on the xml will produce
+```elixir
 [%{attr: ["xsi:type": "d4p1:Answer"], name: :return,
    value: [%{attr: [], name: :title, value: ["Title"]},
     %{attr: [], name: :description, value: ["Description"]}]}]
-Finding nodes
+```
+
+# Finding nodes
 
 Suppose you want to find all the body nodes from this structure:
-
+```elixir
 structure = %{attr: [],
               name: :html,
               value: [%{attr: [], name: :head, value: ["title"]},
@@ -37,23 +47,27 @@ structure = %{attr: [],
                       %{attr: [], name: :footer, value: [%{attr: [], name: :line, value: ["this"]}]},
                       %{attr: [], name: :body, value: [%{attr: [], name: :line, value: ["that"]}]},
                       %{attr: [], name: :"content:encoded", value: ["<p>comet!!</p>"]}]}
+```
 You can call
-
+```elixir
 Quinn.find(structure, :body)
+```
 This will be the result:
-
+```elixir
 [%{attr: [], name: :body, value: ["body1", "body2"]},
  %{attr: [], name: :body, value: [%{attr: [], name: :line, value: ["that"]}]}]
-Or given the structure above, you want to find the node line inside body, then you can invoke it like this:
-
+```
+Or given the structure above, you want to find the node `line` inside `body`, then you can invoke it like this:
+```elixir
 Quinn.find(structure, [:body, :line])
+```
 The result will be
-
+```elixir
 [%{attr: [], name: :line, value: ["that"]}]
+```
 Please refer to the tests if you want to see more example on how it is used.
 
 Please let me know if you come across any problem. I'm still new to Elixir so feel free to contribute or clean up the code.
 
-License
-
+# License
 Quinn source code is released under Apache 2 License. Check LICENSE file for more information.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,34 @@
 Quinn
-=====
 
-A simple XML parser in Elixir aims to parse rss/atom feeds. I'm currently
-using `xmerl_scan.string` to parse the xml. I'm a bit busy so I may take awhile to response and/or update. Feel free to send a pull request. Otherwise, check out [hex](https://hex.pm/packages?search=xml&sort=downloads) for other XML parsers that may be better maintained.
+A simple XML parser in Elixir aims to parse rss/atom feeds. I'm currently using xmerl_scan.string to parse the xml. I'm a bit busy so I may take awhile to response and/or update. Feel free to send a pull request. Otherwise, check out hex for other XML parsers that may be better maintained.
 
 Note: I am not parsing comment at the moment. It does handle comment, but it just ignores it. Hopefully I will update it soon. Sorry!
 
-# Parsing
+Parsing
 
-
-```elixir
 Quinn.parse("<head><title short_name = \"yah\">Yahoo</title><title:content>Bing</title:content></head>")
-```
 Calling parse on the xml will produce
-```elixir
+
 [%{attr: [], name: :head,
    value: [%{attr: [short_name: "yah"], name: :title, value: ["Yahoo"]},
            %{attr: [], name: :"title:content", value: ["Bing"]}]}]
-```
-# Finding nodes
+Parsing xml without namespaces(key prefix)
+
+xml = "<m:return xsi:type="d4p1:Answer">
+      <d4p1:Title> Title </d4p1:Title>
+      <d4p1:Description> Description </d4p1:Description>
+     </m:return>"
+
+Quinn.parse(xml, :strip_namespaces)
+Calling parse on the xml will produce
+
+[%{attr: ["xsi:type": "d4p1:Answer"], name: :return,
+   value: [%{attr: [], name: :title, value: ["Title"]},
+    %{attr: [], name: :description, value: ["Description"]}]}]
+Finding nodes
 
 Suppose you want to find all the body nodes from this structure:
-```elixir
+
 structure = %{attr: [],
               name: :html,
               value: [%{attr: [], name: :head, value: ["title"]},
@@ -30,27 +37,23 @@ structure = %{attr: [],
                       %{attr: [], name: :footer, value: [%{attr: [], name: :line, value: ["this"]}]},
                       %{attr: [], name: :body, value: [%{attr: [], name: :line, value: ["that"]}]},
                       %{attr: [], name: :"content:encoded", value: ["<p>comet!!</p>"]}]}
-```
 You can call
-```elixir
+
 Quinn.find(structure, :body)
-```
 This will be the result:
-```elixir
+
 [%{attr: [], name: :body, value: ["body1", "body2"]},
  %{attr: [], name: :body, value: [%{attr: [], name: :line, value: ["that"]}]}]
-```
-Or given the structure above, you want to find the node `line` inside `body`, then you can invoke it like this:
-```elixir
+Or given the structure above, you want to find the node line inside body, then you can invoke it like this:
+
 Quinn.find(structure, [:body, :line])
-```
 The result will be
-```elixir
+
 [%{attr: [], name: :line, value: ["that"]}]
-```
 Please refer to the tests if you want to see more example on how it is used.
 
 Please let me know if you come across any problem. I'm still new to Elixir so feel free to contribute or clean up the code.
 
-# License
+License
+
 Quinn source code is released under Apache 2 License. Check LICENSE file for more information.

--- a/README.md
+++ b/README.md
@@ -18,21 +18,36 @@ Calling parse on the xml will produce
    value: [%{attr: [short_name: "yah"], name: :title, value: ["Yahoo"]},
            %{attr: [], name: :"title:content", value: ["Bing"]}]}]
 ```
-Parsing xml without namespaces(key prefix)
+### Parsing without namespaces(key prefix)
 ```elixir
 xml = "<m:return xsi:type="d4p1:Answer">
       <d4p1:Title> Title </d4p1:Title>
       <d4p1:Description> Description </d4p1:Description>
      </m:return>"
 
-Quinn.parse(xml, :strip_namespaces)
+Quinn.parse(xml, %{strip_namespaces: true})
 ```
 
 Calling parse on the xml will produce
 ```elixir
-[%{attr: ["xsi:type": "d4p1:Answer"], name: :return,
+[%{attr: ["xsi:type": "d4p1:Answer"],
+   name: :return,
    value: [%{attr: [], name: :title, value: ["Title"]},
-    %{attr: [], name: :description, value: ["Description"]}]}]
+%{attr: [], name: :description, value: ["Description"]}]}]
+```
+
+### Parsing comments
+```elixir
+xml = ~s(<head><title short_name = "yah">Yahoo</title><!--- <test pattern="SECAM" /><test pattern="NTSC" /> --></head>)
+result = Quinn.parse(xml, %{comments: true})
+```
+The xml above will give you this. Note the name is `comments`.
+
+```elixir
+[%{attr: [],
+   name: :head,
+   value: [%{attr: [short_name: "yah"], name: :title, value: ["Yahoo"]},
+           %{attr: [], name: :comments, value: ~s(- <test pattern="SECAM" /><test pattern="NTSC" />)}]}]
 ```
 
 # Finding nodes

--- a/lib/quinn.ex
+++ b/lib/quinn.ex
@@ -1,7 +1,7 @@
 defmodule Quinn do
 
-  def parse(xml) do
-    Quinn.XmlParser.parse(xml)
+  def parse(xml, strip_namespaces \\ nil) do
+    Quinn.XmlParser.parse(xml, strip_namespaces)
   end
 
   def find(node, node_names) do

--- a/lib/xml_parser/xml_parser.ex
+++ b/lib/xml_parser/xml_parser.ex
@@ -19,7 +19,7 @@ defmodule Quinn.XmlParser do
 
   defp parse_record({:xmlElement, name, _, _, _, _, _, attributes, elements, _, _, _}, options) do
     value = combine_values(parse_record(elements, options))
-    if options[:strip_namespaces], do: name = name |> to_string |> String.split(":") |> List.last |> Macro.underscore |> String.to_atom
+    name = parse_name(name, options)
     [%{name: name, attr: parse_attribute(attributes), value: value}]
   end
 
@@ -32,13 +32,8 @@ defmodule Quinn.XmlParser do
     end
   end
 
-  defp parse_record({:xmlComment, _, _, _, _value}, _) do
-    []
-  end
-
+  defp parse_record({:xmlComment, _, _, _, _value}, _), do: []
   defp parse_record([], _), do: []
-
-  defp parse_record([element]), do: parse_record(element)
 
   defp parse_record([head | tail], options) do
     parse_record(head, options) ++ parse_record(tail, options)
@@ -50,11 +45,18 @@ defmodule Quinn.XmlParser do
     [{name, to_string(value)}]
   end
 
-  defp parse_attribute([attribute]) do
-    parse_attribute(attribute)
-  end
-
   defp parse_attribute([head | tail]) do
     parse_attribute(head) ++ parse_attribute(tail)
   end
+
+  defp parse_name(name, %{strip_namespaces: true}) do
+    name
+    |> to_string
+    |> String.split(":")
+    |> List.last
+    |> Macro.underscore
+    |> String.to_atom
+  end
+
+  defp parse_name(name, _), do: name
 end

--- a/lib/xml_parser/xml_parser.ex
+++ b/lib/xml_parser/xml_parser.ex
@@ -32,7 +32,14 @@ defmodule Quinn.XmlParser do
     end
   end
 
-  defp parse_record({:xmlComment, _, _, _, _value}, _), do: []
+  defp parse_record({:xmlComment, _, _, _, value}, options) do
+    if options[:comments] do
+      [%{name: :comments, attr: [], value: String.strip(to_string(value))}]
+    else
+      []
+    end
+  end
+
   defp parse_record([], _), do: []
 
   defp parse_record([head | tail], options) do

--- a/lib/xml_parser/xml_parser.ex
+++ b/lib/xml_parser/xml_parser.ex
@@ -1,10 +1,10 @@
 defmodule Quinn.XmlParser do
 
-  def parse(xml) do
+  def parse(xml, strip_namespaces) do
     :erlang.bitstring_to_list(xml)
     |> :xmerl_scan.string
     |> elem(0)
-    |> parse_record
+    |> parse_record(strip_namespaces)
   end
 
   defp combine_values([]), do: []
@@ -17,12 +17,13 @@ defmodule Quinn.XmlParser do
     end
   end
 
-  defp parse_record({:xmlElement, name, _, _, _, _, _, attributes, elements, _, _, _}) do
-    value = combine_values(parse_record(elements))
+  defp parse_record({:xmlElement, name, _, _, _, _, _, attributes, elements, _, _, _}, strip_namespaces) do
+    value = combine_values(parse_record(elements, strip_namespaces))
+    if strip_namespaces == :strip_namespaces, do: name = name |> to_string |> String.split(":") |> List.last |> Macro.underscore |> String.to_atom
     [%{name: name, attr: parse_attribute(attributes), value: value}]
   end
 
-  defp parse_record({:xmlText, _, _, _, value, _}) do
+  defp parse_record({:xmlText, _, _, _, value, _}, _) do
     string_value = String.strip(to_string(value))
     if (String.length(string_value) > 0) do
       [string_value]
@@ -35,12 +36,12 @@ defmodule Quinn.XmlParser do
     []
   end
 
-  defp parse_record([]), do: []
+  defp parse_record([], _), do: []
 
   defp parse_record([element]), do: parse_record(element)
 
-  defp parse_record([head | tail]) do
-    parse_record(head) ++ parse_record(tail)
+  defp parse_record([head | tail], strip_namespaces) do
+    parse_record(head, strip_namespaces) ++ parse_record(tail, strip_namespaces)
   end
 
   defp parse_attribute([]), do: []

--- a/lib/xml_parser/xml_parser.ex
+++ b/lib/xml_parser/xml_parser.ex
@@ -1,10 +1,10 @@
 defmodule Quinn.XmlParser do
 
-  def parse(xml, strip_namespaces) do
+  def parse(xml, options \\ %{}) do
     :erlang.bitstring_to_list(xml)
     |> :xmerl_scan.string
     |> elem(0)
-    |> parse_record(strip_namespaces)
+    |> parse_record(options)
   end
 
   defp combine_values([]), do: []
@@ -17,9 +17,9 @@ defmodule Quinn.XmlParser do
     end
   end
 
-  defp parse_record({:xmlElement, name, _, _, _, _, _, attributes, elements, _, _, _}, strip_namespaces) do
-    value = combine_values(parse_record(elements, strip_namespaces))
-    if strip_namespaces == :strip_namespaces, do: name = name |> to_string |> String.split(":") |> List.last |> Macro.underscore |> String.to_atom
+  defp parse_record({:xmlElement, name, _, _, _, _, _, attributes, elements, _, _, _}, options) do
+    value = combine_values(parse_record(elements, options))
+    if options[:strip_namespaces], do: name = name |> to_string |> String.split(":") |> List.last |> Macro.underscore |> String.to_atom
     [%{name: name, attr: parse_attribute(attributes), value: value}]
   end
 
@@ -32,7 +32,7 @@ defmodule Quinn.XmlParser do
     end
   end
 
-  defp parse_record({:xmlComment, _, _, _, _value}) do
+  defp parse_record({:xmlComment, _, _, _, _value}, _) do
     []
   end
 
@@ -40,8 +40,8 @@ defmodule Quinn.XmlParser do
 
   defp parse_record([element]), do: parse_record(element)
 
-  defp parse_record([head | tail], strip_namespaces) do
-    parse_record(head, strip_namespaces) ++ parse_record(tail, strip_namespaces)
+  defp parse_record([head | tail], options) do
+    parse_record(head, options) ++ parse_record(tail, options)
   end
 
   defp parse_attribute([]), do: []

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Quinn.Mixfile do
   def project do
     [
       app: :quinn,
-      version: "1.0.2",
+      version: "1.1.0",
       elixir: "~> 1.3",
       deps: deps(),
       description: description(),

--- a/test/xml_parser/xml_parser_test.exs
+++ b/test/xml_parser/xml_parser_test.exs
@@ -52,13 +52,23 @@ defmodule Quinn.XmlParserTest do
     assert expected == Quinn.parse(xml)
   end
 
-  test "comments" do
+  test "ignore comments" do
     xml = "<head><title short_name = \"yah\">Yahoo</title><title:content>Bing</title:content><!-- foo --></head>"
     expected = [%{attr: [],
                   name: :head,
                   value: [%{attr: [short_name: "yah"], name: :title, value: ["Yahoo"]},
                           %{attr: [], name: :"title:content", value: ["Bing"]}]}]
     assert expected == Quinn.parse(xml)
+  end
+
+  test "parse comments" do
+    xml = ~s(<head><title short_name = "yah">Yahoo</title><!--- <test pattern="SECAM" /><test pattern="NTSC" /> --></head>)
+    comments = ~s(- <test pattern="SECAM" /><test pattern="NTSC" />)
+    expected = [%{attr: [],
+                  name: :head,
+                  value: [%{attr: [short_name: "yah"], name: :title, value: ["Yahoo"]},
+                          %{attr: [], name: :comments, value: comments}]}]
+    assert expected == Quinn.parse(xml, %{comments: true})
   end
 
   test "parse small rss feed" do

--- a/test/xml_parser/xml_parser_test.exs
+++ b/test/xml_parser/xml_parser_test.exs
@@ -81,4 +81,17 @@ defmodule Quinn.XmlParserTest do
                   |> Quinn.find([:entry, :title])
     assert hd(title.value) =~ "Wearing The Pants"
   end
+
+  test "parse without namespace" do
+    xml = ~s(<m:return xsi:type="d4p1:Answer"><d4p1:Title> Title </d4p1:Title><d4p1:Description> Description </d4p1:Description></m:return>)
+
+    expected = [%{attr: ["xsi:type": "d4p1:Answer"],
+                  name: :return,
+                  value: [%{attr: [], name: :title, value: ["Title"]},
+                %{attr: [],
+                  name: :description,
+                  value: ["Description"]}]}]
+
+    assert expected == Quinn.parse(xml, %{strip_namespaces: true})
+  end
 end


### PR DESCRIPTION
Hi Nhu Nguyen, recently performing the task of compressing xml data from one service and a problem occurred when parsing data. namely with key prefixes. They changed from time to time, for example, the key was <d4p1: Title>, after a time it changed to <d6p2: Title>, etc. Therefore there was a need to parse without key prefixes.