### PR TITLE
Attributes as map

### DIFF
--- a/lib/xml_parser/xml_parser.ex
+++ b/lib/xml_parser/xml_parser.ex
@@ -26,6 +26,7 @@ defmodule Quinn.XmlParser do
     value = combine_values(parse_record(elements, options))
     name = parse_name(name, options)
     attributes = if options[:map_attributes], do: Map.new(parse_attribute(attributes)), else: parse_attribute(attributes)
+
     [%{name: name, attr: attributes, value: value}]
   end
 

--- a/lib/xml_parser/xml_parser.ex
+++ b/lib/xml_parser/xml_parser.ex
@@ -25,7 +25,8 @@ defmodule Quinn.XmlParser do
   defp parse_record({:xmlElement, name, _, _, _, _, _, attributes, elements, _, _, _}, options) do
     value = combine_values(parse_record(elements, options))
     name = parse_name(name, options)
-    [%{name: name, attr: parse_attribute(attributes), value: value}]
+    attributes = if options[:map_attributes], do: Map.new(parse_attribute(attributes)), else: parse_attribute(attributes)
+    [%{name: name, attr: attributes, value: value}]
   end
 
   defp parse_record({:xmlText, _, _, _, value, _}, _) do

--- a/test/xml_parser/xml_parser_test.exs
+++ b/test/xml_parser/xml_parser_test.exs
@@ -104,4 +104,17 @@ defmodule Quinn.XmlParserTest do
 
     assert expected == Quinn.parse(xml, %{strip_namespaces: true})
   end
+
+  test "parse with attributes as map" do
+    xml = ~s(<m:return xsi:type="d4p1:Answer" desc="bla"><d4p1:Title> Title </d4p1:Title><d4p1:Description> Description </d4p1:Description></m:return>)
+
+    expected = [%{attr: %{"xsi:type": "d4p1:Answer", desc: "bla"},
+                  name: :"m:return",
+                  value: [%{attr: %{}, name: :"d4p1:Title", value: ["Title"]},
+                %{attr: %{},
+                  name: :"d4p1:Description",
+                  value: ["Description"]}]}]
+
+    assert expected == Quinn.parse(xml, %{map_attributes: true})
+  end
 end


### PR DESCRIPTION
Added an option to convert attributes from keyword list to `Map`, this is useful to convert the output xml to json.